### PR TITLE
Update index.md

### DIFF
--- a/src/content/developers/docs/mev/index.md
+++ b/src/content/developers/docs/mev/index.md
@@ -148,7 +148,7 @@ The combination of block producer and block proposer roles is what introduces mo
 
 Under PBS, a block builder creates a transaction bundle and places a bid for its inclusion in a Beacon Chain block (as the “execution payload”). The validator selected to propose the next block then checks the different bids and chooses the bundle with the highest fee. PBS essentially creates an auction market, where builders negotiate with validators selling blockspace.
 
-Current PBS designs use a [commit-reveal scheme](https://gitcoin.co/blog/commit-reveal-scheme-on-ethereum/) in which builders only publish a cryptographic commitment to a block’s contents (block header) along with their bids. After accepting the winning bid, the proposer creates a signed block proposal that includes the block header. The block builder is expected to publish the full block body after seeing the signed block proposal, and it must also receive receive enough [attestations](/glossary/#attestation) from validators before it is finalized.
+Current PBS designs use a [commit-reveal scheme](https://gitcoin.co/blog/commit-reveal-scheme-on-ethereum/) in which builders only publish a cryptographic commitment to a block’s contents (block header) along with their bids. After accepting the winning bid, the proposer creates a signed block proposal that includes the block header. The block builder is expected to publish the full block body after seeing the signed block proposal, and it must also receive enough [attestations](/glossary/#attestation) from validators before it is finalized.
 
 #### How does proposer-builder separation mitigate MEV’s impact? {#how-does-pbs-curb-mev-impact}
 


### PR DESCRIPTION
There were 2 " receive receive " on line 151 in the documentation section of last paragraph of Proposer-Builder Separation. I have simply fixed the 2 " receive receive " into i " receive ". Kindly merge this PR. It will fix the grammar mistake, and the documentation will look good. Thank you!

<!--- Provide a general summary of your changes in the Title above -->

## Description
I was reading about the MEV on ethereum.org. Then I stumbled upon this grammar mistake and I thought I should make a pull request and fix this issue as it creates a hurdle in my learning/reading experience.
<!--- Describe your changes in detail -->

## Related Issue
Typo in the last paragraph of Proposer-Builder Separation Line 151. https://github.com/ethereum/ethereum-org-website/issues/9032
<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
